### PR TITLE
Removes unnecessary language about sending METADATA before negotiation.

### DIFF
--- a/draft-beky-httpbis-metadata.md
+++ b/draft-beky-httpbis-metadata.md
@@ -185,10 +185,7 @@ the default value is 0.  For HTTP/2,
 SETTINGS_ENABLE_METADATA MUST NOT be sent in any SETTINGS frame other than the
 first one.
 
-An endpoint MAY send METADATA frames before it learns that the peer supports
-them.  For example, an HTTP intermediary might chose to forward METADATA frames, or it might
-chose to buffer them, before it receives a SETTINGS frame.  An endpoint SHOULD
-NOT send METADATA frames after it learns that the peer does not support them.
+An endpoint SHOULD NOT send METADATA frames if it learns that the peer does not support them.
 
 # Security Considerations
 


### PR DESCRIPTION
The original HTTP/2 specification that endpoints may send frames of unknown types, so the language isn't necessary here.

This also removes mention of "forwarding" METADATA, which we don't need to include.